### PR TITLE
included module_name in provider meta

### DIFF
--- a/examples/cpem-add-on/versions.tf
+++ b/examples/cpem-add-on/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     equinix = {
       source  = "equinix/equinix"
-      version = ">= 1.10"
+      version = "~> 1.14"
     }
   }
-  required_version = ">= 1"
+  required_version = ">= 1.0.0"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,11 @@ terraform {
   required_providers {
     equinix = {
       source  = "equinix/equinix"
-      version = "1.14.1"
+      version = "~> 1.14"
     }
+  }
+  required_version = ">= 1.0.0"
+  provider_meta "equinix" {
+    module_name = "equinix-kubernetes-cluster"
   }
 }


### PR DESCRIPTION
What this PR does / why we need it:
It allows Vendor to declare the metadata fields. It adds provider meta module_name in Equinix Metal TF configs

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Related to https://github.com/equinix/terraform-provider-equinix/issues/252

