### PR TITLE
fix: use equinix-labs hosted metal actions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,7 +42,7 @@ jobs:
       id: init
       run: terraform init -input=false
     - id: project
-      uses: displague/metal-project-action@v0.10.0
+      uses: equinix-labs/metal-project-action@v0.10.0
       env:
         METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
     - name: Terraform Vars - Cluster Name
@@ -63,7 +63,7 @@ jobs:
       run: terraform destroy -input=false -auto-approve
     - name: Project Delete
       if: ${{ always() }}
-      uses: displague/metal-sweeper-action@v0.3.0
+      uses: equinix-labs/metal-sweeper-action@v0.3.0
       env:
         METAL_PROJECT_ID: ${{ steps.project.outputs.projectID }}
         METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,7 +42,7 @@ jobs:
       id: init
       run: terraform init -input=false
     - id: project
-      uses: equinix-labs/metal-project-action@v0.10.0
+      uses: equinix-labs/metal-project-action@v0.13.0
       env:
         METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
     - name: Terraform Vars - Cluster Name
@@ -63,7 +63,7 @@ jobs:
       run: terraform destroy -input=false -auto-approve
     - name: Project Delete
       if: ${{ always() }}
-      uses: equinix-labs/metal-sweeper-action@v0.3.0
+      uses: equinix-labs/metal-sweeper-action@v0.6.0
       env:
         METAL_PROJECT_ID: ${{ steps.project.outputs.projectID }}
         METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}


### PR DESCRIPTION
Switch the metal-sweeper and metal-device actions to use the versions hosted on equinix-labs.