### PR TITLE
chore: fixed reference to flannel_version var in terraform.tfvars.example file under cluster-with-cni example

### DIFF
--- a/examples/cluster-with-cni/terraform.tfvars.example
+++ b/examples/cluster-with-cni/terraform.tfvars.example
@@ -5,7 +5,7 @@ metal_project_id           = "YOUR_PROJECT_TOKEN_HERE"
 kube_vip_version     = "v0.6.2"
 kubernetes_version   = "v1.28.1"
 metal_metro                = "da"
-# Optional, choose a specific flannel version, leave blank for latest
-flannel_version      = ""
+# Optional, choose a specific flannel version, default is v0.24.2
+# flannel_version      = "v0.24.2"
 # Optional, name of a specific cloud provider. Possible values: external, YOUR_CLOUD_PROVIDER, "" (empty for internal cloud controller)
 cloud_provider_external       = false


### PR DESCRIPTION
This is follow-on PR to merged #54 

- It contains a minor fix reference to flannel_version var in terraform.tfvars.example file under cluster-with-cni example