### PR TITLE
fix: use pkgs.k8s.io apt mirror (previous fails)

### DIFF
--- a/templates/cloud-config-cp-init.tftpl
+++ b/templates/cloud-config-cp-init.tftpl
@@ -61,9 +61,10 @@ runcmd:
   apt-get update
   apt-get remove docker docker-engine containerd runc -y
   apt-get install apt-transport-https ca-certificates curl gnupg lsb-release jq kubetail -y
+  MAJOR_MINOR=$(echo ${KUBERNETES_VERSION} | sed -E 's/v([0-9]+\.[0-9]+).*/\1/')
   mkdir -m 0755 -p /etc/apt/keyrings
-  curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
-  echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+  curl -fsSL https://pkgs.k8s.io/core:/stable:/v$MAJOR_MINOR/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+  echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$MAJOR_MINOR/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
   apt-get update

--- a/templates/cloud-config-worker.tftpl
+++ b/templates/cloud-config-worker.tftpl
@@ -41,9 +41,10 @@ runcmd:
   apt-get update
   apt-get remove docker docker-engine containerd runc -y
   apt-get install apt-transport-https ca-certificates curl gnupg lsb-release jq kubetail -y
+  MAJOR_MINOR=$(echo ${KUBERNETES_VERSION} | sed -E 's/v([0-9]+\.[0-9]+).*/\1/')
   mkdir -m 0755 -p /etc/apt/keyrings
-  curl -fsSL https://dl.k8s.io/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
-  echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+  curl -fsSL https://pkgs.k8s.io/core:/stable:/v$MAJOR_MINOR/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+  echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$MAJOR_MINOR/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
   apt-get update


### PR DESCRIPTION
part of #62 

With this change the K8s CPs successfully install packages during cloud-init:

`/var/log/cloud-init-output.log`:
```
...
[addons] Applied essential addon: CoreDNS
[addons] Applied essential addon: kube-proxy

Your Kubernetes control-plane has initialized successfully!

To start using your cluster, you need to run the following as a regular user:
...
```

```
root@k8s-cluster1-pool1-cp-1:/var/log# kubectl get nodes -o wide 
NAME                      STATUS     ROLES           AGE     VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
k8s-cluster1-pool1-cp-1   NotReady   control-plane   5m56s   v1.27.5   147.28.197.41   <none>        Ubuntu 20.04.6 LTS   5.15.0-97-generic   containerd://1.6.28
```